### PR TITLE
fix: UploadAsset using wrong properties 

### DIFF
--- a/SessionAssetStore/SessionAssetStore.csproj
+++ b/SessionAssetStore/SessionAssetStore.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <Version>1.0.1</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/SessionAssetStore/SessionAssetStore.xml
+++ b/SessionAssetStore/SessionAssetStore.xml
@@ -130,18 +130,19 @@
             <summary>
             Upload an asset to the storage server.
             </summary>
-            <param name="assetManifest">The path of the JSON manifest</param>
-            <param name="asset">The path of the asset</param>
-            <param name="assetThumbnail">The path of the thumbnail of the asset</param>
-            <param name="progress">An array of IProgress objects to report download activities in this specific order: Manifest, Thumbnail, Asset.</param>
+            <param name="assetManifest"> absolute path to the json manifest file </param>
+            <param name="assetThumbnail"> absolute path to the thumbnail image file </param>
+            <param name="asset"> absolute path to the asset file (e.g. a .zip file) </param>
+            <param name="bucketName"> Name of google cloud storage bucket to upload to </param>
+            <param name="progress"> array of IUpload representing progress for [Manifest, Thumbnail, File] in that order. </param>
         </member>
-        <member name="M:SessionAssetStore.StorageManager.DeleteAsset(System.String,System.String)">
+        <member name="M:SessionAssetStore.StorageManager.DeleteAsset(System.String,System.String,System.String)">
             <summary>
             Deletes an asset from the storage server.
             </summary>
             <param name="manifestName">The manifest file of the asset.</param>
         </member>
-        <member name="M:SessionAssetStore.StorageManager.DeleteAsset(System.String,SessionAssetStore.Asset)">
+        <member name="M:SessionAssetStore.StorageManager.DeleteAsset(System.String,System.String,SessionAssetStore.Asset)">
             <summary>
             Deletes an asset from the storage server.
             </summary>


### PR DESCRIPTION
- fixed UploadAsset() using Name instead of AssetName for the object name
- also fixed using the wrong file name for the manifest file
- DeleteAsset() methods updated with bucketName parameter
- added missing .Wait() when uploading manifest file