### PR TITLE
update: add new GetAssetManifestsAsync method

### DIFF
--- a/SessionAssetStore/SessionAssetStore.csproj
+++ b/SessionAssetStore/SessionAssetStore.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
- added alternate `GetAssetManifestsAsync()` method which accepts List of AssetCategories to get manifests for. This allows for downloading manifests for multiple categories at once.
- changed `GetBucketNameAsync()` to list objects from server with a prefix to limit amount of results returned
- increment package version to 1.1.1.0